### PR TITLE
Update third-party URL

### DIFF
--- a/thirdparty.repos
+++ b/thirdparty.repos
@@ -1,9 +1,10 @@
 repositories:
   ThirdParty/worlds/aws-robomaker-small-house-world:
     type: git
-    url: https://github.com/Juancams/aws-robomaker-small-house-world
-    version: ros2-jazzy
+    url: https://github.com/IntelligentRoboticsLabs/aws-robomaker-small-house-world
+    version: ros2
   ThirdParty/robots/kobuki_ros:
     type: git
     url: https://github.com/Juancams/kobuki_ros.git
     version: rolling-simulation
+


### PR DESCRIPTION
Change remote for the `aws-robomaker-small-house-world` package ind `thirdparty.repos`.